### PR TITLE
Add basic login page

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -20,8 +20,10 @@ import Svg, {
 } from 'react-native-svg';
 import { project, YearRow } from './project';
 import DataTableCard from "./components/DataTableCard";
+import LoginScreen from "./components/LoginScreen";
 
 export default function App() {
+  const [loggedIn, setLoggedIn] = useState(false);
   const [tableCollapsed, setTableCollapsed] = useState(true);
   const [plotColumns, setPlotColumns] = useState({
     endBalance: true,
@@ -58,6 +60,9 @@ export default function App() {
     );
     setRows(results);
   };
+  if (!loggedIn) {
+    return <LoginScreen onLogin={() => setLoggedIn(true)} />;
+  }
 
   return (
     <SafeAreaView style={styles.safe}>

--- a/components/LoginScreen.tsx
+++ b/components/LoginScreen.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet, SafeAreaView } from 'react-native';
+
+interface Props {
+  onLogin: () => void;
+}
+
+export default function LoginScreen({ onLogin }: Props) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleLogin = () => {
+    // Placeholder authentication; in a real app you would validate credentials.
+    onLogin();
+  };
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <View style={styles.container}>
+        <Text style={styles.title}>Login</Text>
+        <View style={styles.inputGroup}>
+          <Text style={styles.inputLabel}>Username</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="Username"
+            placeholderTextColor="#888"
+            keyboardAppearance="dark"
+            value={username}
+            onChangeText={setUsername}
+          />
+        </View>
+        <View style={styles.inputGroup}>
+          <Text style={styles.inputLabel}>Password</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="Password"
+            placeholderTextColor="#888"
+            secureTextEntry
+            keyboardAppearance="dark"
+            value={password}
+            onChangeText={setPassword}
+          />
+        </View>
+        <TouchableOpacity style={styles.button} onPress={handleLogin}>
+          <Text style={styles.buttonText}>Login</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: '#0D0D0D',
+    justifyContent: 'center',
+  },
+  container: {
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 20,
+    textAlign: 'center',
+    color: '#fff',
+  },
+  inputGroup: {
+    marginBottom: 12,
+  },
+  inputLabel: {
+    color: '#fff',
+    marginBottom: 4,
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#333',
+    backgroundColor: '#1C1C1E',
+    padding: 10,
+    borderRadius: 4,
+    color: '#fff',
+  },
+  button: {
+    backgroundColor: '#00C805',
+    padding: 12,
+    borderRadius: 4,
+    alignItems: 'center',
+    marginTop: 10,
+  },
+  buttonText: {
+    color: '#000',
+    fontWeight: 'bold',
+  },
+});
+


### PR DESCRIPTION
## Summary
- Introduce `LoginScreen` component with username and password inputs.
- Gate main calculator behind login by conditionally rendering `LoginScreen` in `App`.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68990c53dca4832e9437cd895b490efd