### PR TITLE
feat: save and load calculator scenarios

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -20,6 +20,7 @@ import Svg, {
 } from 'react-native-svg';
 import { project, YearRow } from './project';
 import DataTableCard from "./components/DataTableCard";
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export default function App() {
   const [tableCollapsed, setTableCollapsed] = useState(true);
@@ -42,6 +43,42 @@ export default function App() {
   const [withdrawPercent, setWithdrawPercent] = useState('4');
   const [withdrawAmount, setWithdrawAmount] = useState('10000');
   const [rows, setRows] = useState<YearRow[]>([]);
+
+  const STORAGE_KEY = 'fire-calculator-scenario';
+
+  const handleSave = async () => {
+    try {
+      const scenario = {
+        initialAmount,
+        annualReturnRate,
+        annualContribution,
+        withdrawStartYear,
+        withdrawType,
+        withdrawPercent,
+        withdrawAmount,
+      };
+      await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(scenario));
+    } catch {
+      // ignore write errors
+    }
+  };
+
+  const handleLoad = async () => {
+    try {
+      const json = await AsyncStorage.getItem(STORAGE_KEY);
+      if (!json) return;
+      const scenario = JSON.parse(json);
+      setInitialAmount(scenario.initialAmount ?? '');
+      setAnnualReturnRate(scenario.annualReturnRate ?? '');
+      setAnnualContribution(scenario.annualContribution ?? '');
+      setWithdrawStartYear(scenario.withdrawStartYear ?? '');
+      setWithdrawType(scenario.withdrawType === 'amount' ? 'amount' : 'percent');
+      setWithdrawPercent(scenario.withdrawPercent ?? '');
+      setWithdrawAmount(scenario.withdrawAmount ?? '');
+    } catch {
+      // ignore read errors
+    }
+  };
 
   React.useEffect(() => {
     if (rows.length > 0) setTableCollapsed(false);
@@ -181,6 +218,14 @@ export default function App() {
             <Text style={styles.plotOptionText}>Start Balance</Text>
           </TouchableOpacity>
         </View>
+      </View>
+      <View style={styles.saveLoadRow}>
+        <TouchableOpacity style={[styles.button, styles.halfButton, styles.saveButton]} onPress={handleSave}>
+          <Text style={styles.buttonText}>Save</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={[styles.button, styles.halfButton]} onPress={handleLoad}>
+          <Text style={styles.buttonText}>Load</Text>
+        </TouchableOpacity>
       </View>
       <TouchableOpacity style={styles.button} onPress={handleCalculate}>
         <Text style={styles.buttonText}>Project</Text>
@@ -518,6 +563,17 @@ const styles = StyleSheet.create({
     borderRadius: 4,
     alignItems: 'center',
     marginTop: 10,
+  },
+  saveLoadRow: {
+    flexDirection: 'row',
+    marginTop: 10,
+  },
+  halfButton: {
+    flex: 1,
+    marginTop: 0,
+  },
+  saveButton: {
+    marginRight: 10,
   },
   buttonText: {
     color: '#000',

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ An offline Expo + React Native app that projects an investment balance once per 
 
 Styled with a dark theme and green accents inspired by the Robinhood app.
 
+Includes buttons to save and load scenario inputs using local storage.
+
 ## Edge Cases
 - Negative or zero annual return rate.
 - Immediate withdrawal when `withdrawStartYear` is 0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "fire-calcultor",
       "version": "1.0.0",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "^2.2.0",
         "expo": "~53.0.20",
         "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
@@ -2585,6 +2586,18 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -5284,6 +5297,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -6704,6 +6726,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^2.2.0",
     "expo": "~53.0.20",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",


### PR DESCRIPTION
## Summary
- add AsyncStorage-based save/load for scenario inputs with buttons
- document save/load support in README
- include AsyncStorage dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899473c77a0832e8967f8a2fd66d564