### PR TITLE
Add responsive web interface

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fire Calculator Web</title>
+  <link rel="stylesheet" href="styles.css" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+  <div class="container">
+    <h1>Fire Calculator</h1>
+    <div class="form-group">
+      <label for="initialAmount">Initial Amount</label>
+      <input id="initialAmount" type="number" />
+    </div>
+    <div class="form-group">
+      <label for="annualReturnRate">Annual Return Rate (%)</label>
+      <input id="annualReturnRate" type="number" />
+    </div>
+    <div class="form-group">
+      <label for="annualContribution">Annual Contribution</label>
+      <input id="annualContribution" type="number" />
+    </div>
+    <div class="form-group">
+      <label for="withdrawStartYear">Withdraw Start Year</label>
+      <input id="withdrawStartYear" type="number" />
+    </div>
+    <div class="form-group">
+      <label for="withdrawType">Withdraw Type</label>
+      <select id="withdrawType">
+        <option value="percent" selected>Percent</option>
+        <option value="amount">Amount</option>
+      </select>
+    </div>
+    <div class="form-group" id="withdrawPercentGroup">
+      <label for="withdrawPercent">Withdraw Percent (%)</label>
+      <input id="withdrawPercent" type="number" />
+    </div>
+    <div class="form-group hidden" id="withdrawAmountGroup">
+      <label for="withdrawAmount">Withdraw Amount</label>
+      <input id="withdrawAmount" type="number" />
+    </div>
+    <div class="plot-section">
+      <p class="plot-label">Plot Columns:</p>
+      <div class="plot-options">
+        <label class="plot-option"><input type="checkbox" data-column="endBalance" checked /> End Balance</label>
+        <label class="plot-option"><input type="checkbox" data-column="contribution" checked /> Contribution</label>
+        <label class="plot-option"><input type="checkbox" data-column="withdrawal" /> Withdrawal</label>
+        <label class="plot-option"><input type="checkbox" data-column="growth" /> Growth</label>
+        <label class="plot-option"><input type="checkbox" data-column="startBalance" /> Start Balance</label>
+      </div>
+    </div>
+    <button id="calculateButton">Calculate</button>
+    <div class="button-row">
+      <button id="saveButton">Save Scenario</button>
+      <button id="loadButton">Load Scenario</button>
+    </div>
+    <canvas id="chart"></canvas>
+    <div class="table-container">
+      <table id="resultsTable">
+        <thead>
+          <tr>
+            <th>Year</th>
+            <th>Start</th>
+            <th>Contribution</th>
+            <th>Withdrawal</th>
+            <th>Growth</th>
+            <th>End</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+  <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/web/project.js
+++ b/web/project.js
@@ -1,0 +1,37 @@
+export function project(initialAmount, annualReturnRate, annualContribution, withdrawStartYear, withdrawPercent, withdrawAmount) {
+  const rows = [];
+  let balance = initialAmount;
+  for (let year = 0; year < 60 && balance > 0; year++) {
+    const startBalance = balance;
+    let withdrawal = 0;
+    let contribution = 0;
+    if (year >= withdrawStartYear) {
+      if (withdrawAmount !== undefined && withdrawAmount !== null) {
+        withdrawal = withdrawAmount;
+        balance -= withdrawal;
+      } else {
+        withdrawal = balance * (withdrawPercent / 100);
+        balance -= withdrawal;
+      }
+    }
+    balance *= 1 + annualReturnRate / 100;
+    const growth = balance - (startBalance - withdrawal);
+    if (year < withdrawStartYear) {
+      contribution = annualContribution;
+      balance += contribution;
+    }
+    const endBalance = balance;
+    rows.push({
+      year,
+      startBalance,
+      contribution,
+      withdrawal,
+      growth,
+      endBalance,
+    });
+    if (endBalance <= 0) {
+      break;
+    }
+  }
+  return rows;
+}

--- a/web/script.js
+++ b/web/script.js
@@ -1,0 +1,129 @@
+import { project } from './project.js';
+
+const initialAmountInput = document.getElementById('initialAmount');
+const annualReturnRateInput = document.getElementById('annualReturnRate');
+const annualContributionInput = document.getElementById('annualContribution');
+const withdrawStartYearInput = document.getElementById('withdrawStartYear');
+const withdrawTypeSelect = document.getElementById('withdrawType');
+const withdrawPercentInput = document.getElementById('withdrawPercent');
+const withdrawAmountInput = document.getElementById('withdrawAmount');
+const withdrawPercentGroup = document.getElementById('withdrawPercentGroup');
+const withdrawAmountGroup = document.getElementById('withdrawAmountGroup');
+const calculateButton = document.getElementById('calculateButton');
+const saveButton = document.getElementById('saveButton');
+const loadButton = document.getElementById('loadButton');
+const resultsTableBody = document.querySelector('#resultsTable tbody');
+const plotOptions = document.querySelectorAll('.plot-option input');
+let chart;
+
+function updateWithdrawFields() {
+  if (withdrawTypeSelect.value === 'percent') {
+    withdrawPercentGroup.classList.remove('hidden');
+    withdrawAmountGroup.classList.add('hidden');
+  } else {
+    withdrawPercentGroup.classList.add('hidden');
+    withdrawAmountGroup.classList.remove('hidden');
+  }
+}
+
+withdrawTypeSelect.addEventListener('change', updateWithdrawFields);
+updateWithdrawFields();
+
+function getScenario() {
+  return {
+    initialAmount: Number(initialAmountInput.value) || 0,
+    annualReturnRate: Number(annualReturnRateInput.value) || 0,
+    annualContribution: Number(annualContributionInput.value) || 0,
+    withdrawStartYear: parseInt(withdrawStartYearInput.value, 10) || 0,
+    withdrawType: withdrawTypeSelect.value,
+    withdrawPercent: Number(withdrawPercentInput.value) || 0,
+    withdrawAmount: Number(withdrawAmountInput.value) || 0,
+  };
+}
+
+function calculate() {
+  const scenario = getScenario();
+  const rows = project(
+    scenario.initialAmount,
+    scenario.annualReturnRate,
+    scenario.annualContribution,
+    scenario.withdrawStartYear,
+    scenario.withdrawType === 'percent' ? scenario.withdrawPercent : 0,
+    scenario.withdrawType === 'amount' ? scenario.withdrawAmount : undefined
+  );
+  renderTable(rows);
+  renderChart(rows);
+}
+
+calculateButton.addEventListener('click', calculate);
+
+function renderTable(rows) {
+  resultsTableBody.innerHTML = '';
+  rows.forEach((r) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${r.year}</td>
+      <td>${r.startBalance.toFixed(2)}</td>
+      <td>${r.contribution.toFixed(2)}</td>
+      <td>${r.withdrawal.toFixed(2)}</td>
+      <td>${r.growth.toFixed(2)}</td>
+      <td>${r.endBalance.toFixed(2)}</td>
+    `;
+    resultsTableBody.appendChild(tr);
+  });
+}
+
+function getSelectedColumns() {
+  const cols = [];
+  plotOptions.forEach((chk) => {
+    if (chk.checked) cols.push(chk.dataset.column);
+  });
+  return cols;
+}
+
+plotOptions.forEach((chk) => chk.addEventListener('change', () => {
+  if (chart) calculate();
+}));
+
+function renderChart(rows) {
+  const labels = rows.map((r) => r.year);
+  const selected = getSelectedColumns();
+  const datasets = selected.map((col) => ({
+    label: col,
+    data: rows.map((r) => r[col]),
+    borderWidth: 2,
+    fill: false,
+  }));
+  if (chart) chart.destroy();
+  chart = new Chart(document.getElementById('chart'), {
+    type: 'line',
+    data: { labels, datasets },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+    },
+  });
+}
+
+const STORAGE_KEY = 'fire-calculator-scenario';
+
+saveButton.addEventListener('click', () => {
+  const name = prompt('Enter scenario name');
+  if (!name) return;
+  const scenario = { ...getScenario(), name };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(scenario));
+});
+
+loadButton.addEventListener('click', () => {
+  const json = localStorage.getItem(STORAGE_KEY);
+  if (!json) return;
+  const scenario = JSON.parse(json);
+  initialAmountInput.value = scenario.initialAmount ?? '';
+  annualReturnRateInput.value = scenario.annualReturnRate ?? '';
+  annualContributionInput.value = scenario.annualContribution ?? '';
+  withdrawStartYearInput.value = scenario.withdrawStartYear ?? '';
+  withdrawTypeSelect.value = scenario.withdrawType === 'amount' ? 'amount' : 'percent';
+  withdrawPercentInput.value = scenario.withdrawPercent ?? '';
+  withdrawAmountInput.value = scenario.withdrawAmount ?? '';
+  updateWithdrawFields();
+});

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,0 +1,100 @@
+body {
+  background-color: #0D0D0D;
+  color: #fff;
+  font-family: Arial, sans-serif;
+  margin: 0;
+}
+
+.container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+h1 {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.form-group {
+  margin-bottom: 12px;
+  display: flex;
+  flex-direction: column;
+}
+
+.form-group label {
+  margin-bottom: 4px;
+}
+
+.form-group input,
+.form-group select {
+  padding: 8px;
+  border: 1px solid #333;
+  border-radius: 4px;
+  background-color: #1C1C1E;
+  color: #fff;
+}
+
+.hidden {
+  display: none;
+}
+
+.button-row {
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+button {
+  flex: 1;
+  padding: 12px;
+  background-color: #00C805;
+  color: #000;
+  border: none;
+  border-radius: 4px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.plot-section {
+  margin: 18px 0;
+}
+
+.plot-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.plot-option {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.table-container {
+  overflow-x: auto;
+  margin-top: 20px;
+}
+
+#resultsTable {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+#resultsTable th,
+#resultsTable td {
+  border: 1px solid #333;
+  padding: 6px;
+  text-align: right;
+}
+
+#resultsTable th {
+  background-color: #1C1C1E;
+}
+
+@media (max-width: 480px) {
+  .plot-options {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- add responsive web version of Fire Calculator using vanilla JS and Chart.js
- include projection logic and UI for inputs, chart, and table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab54922468832e95b6bdd3d9fc45e8