### PR TITLE
Add login button and basic authentication

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -23,6 +23,7 @@ import Svg, {
 import { project, YearRow } from './project';
 import DataTableCard from "./components/DataTableCard";
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { LoginProvider, LoginButton, LoginForm } from './components/Login';
 
 export default function App() {
   const [tableCollapsed, setTableCollapsed] = useState(true);
@@ -122,10 +123,13 @@ export default function App() {
   };
 
   return (
-    <SafeAreaView style={styles.safe}>
-      <ScrollView contentContainerStyle={styles.container}>
-        <Text style={styles.title}>Fire Calculator</Text>
-        <Text style={styles.title}>Financial Independence & Retire Early</Text>
+    <LoginProvider>
+      <SafeAreaView style={styles.safe}>
+        <LoginButton />
+        <ScrollView contentContainerStyle={styles.container}>
+          <LoginForm />
+          <Text style={styles.title}>Fire Calculator</Text>
+          <Text style={styles.title}>Financial Independence & Retire Early</Text>
       <View style={styles.inputGroup}>
         <Text style={styles.inputLabel}>Initial Amount</Text>
         <TextInput
@@ -294,6 +298,7 @@ export default function App() {
       }
       </ScrollView>
     </SafeAreaView>
+  </LoginProvider>
   );
 }
 

--- a/components/Login.test.ts
+++ b/components/Login.test.ts
@@ -1,0 +1,16 @@
+jest.mock('react-native', () => ({
+  Alert: { alert: jest.fn() },
+  StyleSheet: { create: () => ({}) },
+}));
+
+import { validateCredentials } from './Login';
+
+describe('validateCredentials', () => {
+  it('returns true for correct credentials', () => {
+    expect(validateCredentials('user', 'pass123')).toBe(true);
+  });
+
+  it('returns false for incorrect credentials', () => {
+    expect(validateCredentials('wrong', 'creds')).toBe(false);
+  });
+});

--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -1,0 +1,191 @@
+import React, { createContext, useContext, useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity, Alert, StyleSheet, Modal } from 'react-native';
+
+interface LoginContextValue {
+  isLoggedIn: boolean;
+  showLogin: boolean;
+  username: string;
+  password: string;
+  setShowLogin: (v: boolean) => void;
+  setUsername: (v: string) => void;
+  setPassword: (v: string) => void;
+  handleLogin: () => void;
+  handleLogout: () => void;
+}
+
+const LoginContext = createContext<LoginContextValue | undefined>(undefined);
+
+export const validateCredentials = (username: string, password: string) =>
+  username.trim() === 'user' && password === 'pass123';
+
+export const LoginProvider = ({ children }: { children: React.ReactNode }) => {
+  const [showLogin, setShowLogin] = useState(false);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  const handleLogin = () => {
+    if (validateCredentials(username, password)) {
+      setIsLoggedIn(true);
+      setShowLogin(false);
+      setUsername('');
+      setPassword('');
+    } else {
+      Alert.alert('Login failed', 'Invalid username or password');
+    }
+  };
+
+  const handleLogout = () => {
+    setIsLoggedIn(false);
+  };
+
+  return (
+    <LoginContext.Provider
+      value={{
+        isLoggedIn,
+        showLogin,
+        username,
+        password,
+        setShowLogin,
+        setUsername,
+        setPassword,
+        handleLogin,
+        handleLogout,
+      }}
+    >
+      {children}
+    </LoginContext.Provider>
+  );
+};
+
+export const useLogin = () => {
+  const ctx = useContext(LoginContext);
+  if (!ctx) throw new Error('useLogin must be used within LoginProvider');
+  return ctx;
+};
+
+export const LoginButton = () => {
+  const { isLoggedIn, setShowLogin, handleLogout } = useLogin();
+  return isLoggedIn ? (
+    <TouchableOpacity style={styles.loginButton} onPress={handleLogout}>
+      <Text style={styles.loginButtonText}>Logout</Text>
+    </TouchableOpacity>
+  ) : (
+    <TouchableOpacity style={styles.loginButton} onPress={() => setShowLogin(true)}>
+      <Text style={styles.loginButtonText}>Login</Text>
+    </TouchableOpacity>
+  );
+};
+
+export const LoginForm = () => {
+  const {
+    showLogin,
+    isLoggedIn,
+    username,
+    password,
+    setUsername,
+    setPassword,
+    setShowLogin,
+    handleLogin,
+  } = useLogin();
+
+  return (
+    <Modal
+      transparent
+      animationType="fade"
+      visible={showLogin && !isLoggedIn}
+      onRequestClose={() => setShowLogin(false)}
+    >
+      <View style={styles.modalOverlay}>
+        <View style={styles.loginForm}>
+          <Text style={styles.loginTitle}>User Login</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="Username"
+            placeholderTextColor="#888"
+            keyboardAppearance="dark"
+            value={username}
+            onChangeText={setUsername}
+          />
+          <TextInput
+            style={styles.input}
+            placeholder="Password"
+            placeholderTextColor="#888"
+            keyboardAppearance="dark"
+            secureTextEntry
+            value={password}
+            onChangeText={setPassword}
+          />
+          <TouchableOpacity style={styles.button} onPress={handleLogin}>
+            <Text style={styles.buttonText}>Login</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.button, styles.cancelButton]}
+            onPress={() => setShowLogin(false)}
+          >
+            <Text style={styles.buttonText}>Cancel</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  loginButton: {
+    position: 'absolute',
+    top: 10,
+    right: 10,
+    backgroundColor: '#00C805',
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 4,
+  },
+  loginButtonText: {
+    color: '#000',
+    fontWeight: 'bold',
+  },
+  loginForm: {
+    backgroundColor: '#1C1C1E',
+    padding: 20,
+    borderRadius: 8,
+    width: '80%',
+  },
+  loginTitle: {
+    color: '#fff',
+    fontSize: 18,
+    marginBottom: 10,
+    textAlign: 'center',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#333',
+    backgroundColor: '#1C1C1E',
+    padding: 10,
+    borderRadius: 4,
+    color: '#fff',
+  },
+  button: {
+    backgroundColor: '#00C805',
+    padding: 12,
+    borderRadius: 4,
+    alignItems: 'center',
+    marginTop: 10,
+  },
+  buttonText: {
+    color: '#000',
+    fontWeight: 'bold',
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  cancelButton: {
+    backgroundColor: '#555',
+    marginTop: 8,
+  },
+});
+
+export default LoginProvider;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,12 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  globals: {
+    'ts-jest': {
+      tsconfig: {
+        jsx: 'react-jsx',
+        module: 'commonjs',
+      },
+    },
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,9 @@
         "@babel/core": "^7.25.2",
         "@types/jest": "^29.5.11",
         "@types/react": "~19.0.10",
+        "@types/react-test-renderer": "^19.1.0",
         "jest": "^29.7.0",
+        "react-test-renderer": "^19.0.0",
         "ts-jest": "^29.1.1",
         "typescript": "~5.8.3"
       }
@@ -3014,6 +3016,16 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-test-renderer": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
+      "integrity": "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -8359,6 +8371,27 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.0.0.tgz",
+      "integrity": "sha512-oX5u9rOQlHzqrE/64CNr0HB0uWxkCQmZNSfozlYvwE71TLVgeZxVf0IjouGEr1v7r1kcDifdAJBeOhdhxsG/DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^19.0.0",
+        "scheduler": "^0.25.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/react-is": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/regenerate": {
       "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -10,21 +10,23 @@
     "test": "jest"
   },
   "dependencies": {
+    "@expo/metro-runtime": "~5.0.4",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "expo": "~53.0.20",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
+    "react-dom": "19.0.0",
     "react-native": "0.79.5",
     "react-native-svg": "^15.12.1",
-    "react-dom": "19.0.0",
-    "react-native-web": "^0.20.0",
-    "@expo/metro-runtime": "~5.0.4"
+    "react-native-web": "^0.20.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/jest": "^29.5.11",
     "@types/react": "~19.0.10",
+    "@types/react-test-renderer": "^19.1.0",
     "jest": "^29.7.0",
+    "react-test-renderer": "^19.0.0",
     "ts-jest": "^29.1.1",
     "typescript": "~5.8.3"
   },


### PR DESCRIPTION
## Summary
- factor out credential validation into reusable function
- add unit tests covering valid and invalid login credentials

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab64f38e54832e8c3df1a6b2ba0aff